### PR TITLE
Changing global prefix measurement

### DIFF
--- a/lib/metric_collector/collector.py
+++ b/lib/metric_collector/collector.py
@@ -8,7 +8,7 @@ from metric_collector import json_collector
 from metric_collector import utils
 
 logger = logging.getLogger('collector')
-global_measurement_prefix = 'metric_collector'
+global_measurement_prefix = 'metric_collector_external'
 
 class Collector:
 


### PR DESCRIPTION
This allows us to differentiate between the single-vendor external collector and the internal collector. This is in response to making sure our alerting can be separated out between the two collectors until we deprecate the external collector.

I choose to rename this one so it's less disruptive meaning:
1. We do not need to change our alerts because we want to only alert on the the internal collector
2. We will not have to push our the internal collectors once we deprecate this by renaming the global_prefix yet again